### PR TITLE
B1 bugs and refactor

### DIFF
--- a/api/jada_functions.js
+++ b/api/jada_functions.js
@@ -548,7 +548,7 @@ async function apply_to_job() {
             // let clickSubmit = await driver.findElement({ id: 'btnSubmit' }).click();
             // let returnToSearch = await driver.wait(WebDriver.until.elementLocated({
             //     className: 'return-to-search'
-            // }), 10000);
+            // }), 20000);
             //
             // let submissionSuccessful = await driver.findElements({ className: 'return-to-search' });
             // if (submissionSuccessful.length > 0) {

--- a/api/jada_functions.js
+++ b/api/jada_functions.js
@@ -1073,27 +1073,6 @@ exports.email_session_report = async function(searchParams, sessionReport) {
             ${display_email_keyWords(sessionReport.locations_overview, sessionReport.locations_all)}
             <br>
             <br>
-
-            <h1>Jada - All Sessions Report</h1>
-            <br>
-            <h3>All applications processed overview:</h3>
-            <p>Total processed: ${allSessionsReport.total_processed}</p>
-            <p>Total applied: ${allSessionsReport.total_applied}</p>
-            <p>Total skipped: ${allSessionsReport.total_skipped}</p>
-            
-            <h3>Desired Key Words Overview For ALL Applications:</h3>
-            ${display_email_keyWords(allSessionsReport.total_dkw_overview, allSessionsReport.total_dkw_all)}
-            <br>
-            <h3>Undesired Key Words Overview For ALL Applications:</h3>
-            ${display_email_keyWords(allSessionsReport.total_udkw_overview, allSessionsReport.total_udkw_all)}
-            <br>
-            <h3>Top 24 Programing Languages Overview For ALL Applications:</h3>
-            ${display_email_keyWords(allSessionsReport.total_top24_overview, allSessionsReport.total_top24_all)}
-            <br>
-            <h3>Locations Found Overview For ALL APPLIED Applications:</h3>
-            ${display_email_keyWords(allSessionsReport.total_locations_overview, allSessionsReport.total_locations_all)}
-            <br>
-            <br>
         `
     }
 

--- a/api/run_jada.js
+++ b/api/run_jada.js
@@ -16,7 +16,7 @@ const udkw = [
 // BEFORE RUNNING <---> SWITCH FROM TEST BUILD USING CL
 const jobTitle = 'Junior Software Engineer';
 const area = 'Kent';
-const radius = 5;
+const radius = 0;
 
 run_jada(jobTitle, area, radius);
 

--- a/jada-app/src/Components/Charts/BarChartDKW/BarChartDKW.js
+++ b/jada-app/src/Components/Charts/BarChartDKW/BarChartDKW.js
@@ -24,7 +24,8 @@ class BarChartDKW extends React.Component {
     }
 
     keyWordCount = (keyWord, array) => {
-        return array.filter(word => word === keyWord)
+        let keyWordFound = array.filter(word => word === keyWord);
+        return keyWordFound.length
     }
 
     mapKeyWord = (applications) => {
@@ -66,7 +67,7 @@ class BarChartDKW extends React.Component {
         let keyWordsSingle = this.removeDuplicates(keyWordsAll)
 
         keyWordsSingle.forEach(keyWord => {
-            keyWordsCount.push(this.keyWordCount(keyWord, keyWordsAll).length)
+            keyWordsCount.push(this.keyWordCount(keyWord, keyWordsAll))
         })
 
         keyWordData.labels.push(...keyWordsSingle)

--- a/jada-app/src/Components/Charts/BarChartLocations/BarChartLocations.js
+++ b/jada-app/src/Components/Charts/BarChartLocations/BarChartLocations.js
@@ -23,7 +23,8 @@ class BarChartLocations extends React.Component {
     }
 
     locationCount = (location, locationsArr) => {
-        return locationsArr.filter(item => item === location)
+        let locationFound = locationsArr.filter(word => word === location);
+        return locationFound.length
     }
 
     mapLocations = (applications) => {
@@ -70,7 +71,7 @@ class BarChartLocations extends React.Component {
         let locationsSingle = this.removeDuplicates(locationsAll)
 
         locationsSingle.forEach(location => {
-            locationsCount.push(this.locationCount(location, locationsAll).length)
+            locationsCount.push(this.locationCount(location, locationsAll))
         })
 
         for (let i=0; i < locationsSingle.length; i++) {

--- a/jada-app/src/Components/Charts/BarChartTop24/BarChartTop24.js
+++ b/jada-app/src/Components/Charts/BarChartTop24/BarChartTop24.js
@@ -23,7 +23,26 @@ class BarChartTop24 extends React.Component {
     }
 
     languageCount = (language, languageArr) => {
-        return languageArr.filter(word => word === language)
+        let languageFound = languageArr.filter(word => word === language);
+        return languageFound.length
+    }
+
+    javaScriptCount = () => {
+        let applications = this.props.applications;
+        let jS = [];
+        let dkw = [];
+
+        applications.forEach(application => {
+            dkw.push(...application.found_dkw)
+        })
+
+        for (let i=0; i < dkw.length; i++) {
+            if (dkw[i] === 'JAVASCRIPT' || dkw[i] === 'JS') {
+                jS.push(dkw[i])
+            }
+        }
+
+        return jS.length
     }
 
     mapLanguages = (applications) => {
@@ -37,6 +56,19 @@ class BarChartTop24 extends React.Component {
     removeDuplicates = (array) => {
         return array.reduce((unique, item) =>
             unique.includes(item) ? unique : [...unique, item],[]);
+    }
+
+    updateTop24CountForJS = (languageSingle, currentCounts) => {
+        let updatedCounts = [];
+        updatedCounts.push(...currentCounts);
+        let jsCount = this.javaScriptCount();
+        for (let i=0; i < languageSingle.length; i++) {
+            if (languageSingle[i] === 'JAVASCRIPT') {
+                updatedCounts[i] = jsCount
+            }
+        }
+
+        return updatedCounts
     }
 
     updateTop24Data = () => {
@@ -54,13 +86,16 @@ class BarChartTop24 extends React.Component {
         let languagesSingle = this.removeDuplicates(languagesAll);
 
         languagesSingle.forEach(language => {
-            languagesCount.push(this.languageCount(language, languagesAll).length)
+            languagesCount.push(this.languageCount(language, languagesAll))
         })
 
+        let updatedLanguagesCount = this.updateTop24CountForJS(languagesSingle, languagesCount)
+
         languageData.labels.push(...languagesSingle);
-        languageData.datasets[0].data.push(...languagesCount)
+        languageData.datasets[0].data.push(...updatedLanguagesCount)
 
         this.setState({ data: languageData })
+
     }
 
     render() {

--- a/jada-app/src/Components/Charts/BarChartUDKW/BarChartUDKW.js
+++ b/jada-app/src/Components/Charts/BarChartUDKW/BarChartUDKW.js
@@ -24,7 +24,8 @@ class BarChartUDKW extends React.Component {
     }
 
     keyWordCount = (keyWord, array) => {
-        return array.filter(word => word === keyWord)
+        let keyWordFound = array.filter(word => word === keyWord);
+        return keyWordFound.length
     }
 
     mapKeyWord = (applications) => {
@@ -55,7 +56,7 @@ class BarChartUDKW extends React.Component {
         let keyWordsSingle = this.removeDuplicates(keyWordsAll)
 
         keyWordsSingle.forEach(keyWord => {
-            keyWordsCount.push(this.keyWordCount(keyWord, keyWordsAll).length)
+            keyWordsCount.push(this.keyWordCount(keyWord, keyWordsAll))
         })
 
         keyWordData.labels.push(...keyWordsSingle)


### PR DESCRIPTION
Refactored:
- top 24 chart so that JAVASCRIPT displays total including 'JS' key words found.
- Timeout bug that crashes JADA process, triggered when clicking apply on an application takes longer than 10 seconds to load.
- Removed feature that included a break down of all sessions within the email post session run time.

Files changed:
- `jada_functions` : wait time on `apply_to_job()` function from 10 seconds to 20.
- `run_jada` : default test radius from 5 miles to 0
- `BarChartDKW` : key word count method to return count instead of array
- `BarChartUDKW` : key word count method to return count instead of array
- `BarChartLocations` : location count method to return count instead of array
- `BarChartTop24` : function to amend bar chart stats for JavaScript as well as key language count method to return count instead of array
