### PR TITLE
E3 02 logging user ids with applications

### DIFF
--- a/api/controllers/applicationsController.js
+++ b/api/controllers/applicationsController.js
@@ -68,7 +68,7 @@ exports.get_by_session_id = (req, res, next) => {
                     return {
                         _id: doc._id,
                         TEST_application: doc.TEST_application,
-                        user_id: doc.u,
+                        user_id: doc.user_id,
                         session_id: doc.session_id,
                         session_date: doc.session_date,
                         session_time: doc.session_time,
@@ -109,6 +109,61 @@ exports.get_by_session_id = (req, res, next) => {
             });
         })
 };
+
+exports.get_by_user_id = (req, res, next) => {
+    let userId = req.params.userId
+    Application
+        .find({ "user_id" : userId })
+        .exec()
+        .then(docs => {
+            const response = {
+                status: 200,
+                count: docs.length,
+                applications: docs.map(doc => {
+                    return {
+                        _id: doc._id,
+                        TEST_application: doc.TEST_application,
+                        user_id: doc.user_id,
+                        session_id: doc.session_id,
+                        session_date: doc.session_date,
+                        session_time: doc.session_time,
+                        job_title: doc.job_title,
+                        totalJobs_id: doc.totalJobs_id,
+                        apply_attempted: doc.apply_attempted,
+                        interested: doc.interested,
+                        salary: doc.salary,
+                        company: doc.company,
+                        job_type: doc.job_type,
+                        job_posted: doc.job_posted,
+                        location: doc.location,
+                        job_url: doc.job_url,
+                        job_contact: doc.job_contact,
+                        totalJobs_ref: doc.totalJobs_ref,
+                        found_dkw: doc.found_dkw,
+                        found_udkw: doc.found_udkw,
+                        found_top24: doc.found_top24
+
+                    }
+                })
+            }
+
+            if (docs.length > 0) {
+                res.status(200).json({response})
+            } else {
+                res.status(404).json({
+                    status: 404,
+                    message: 'no data in db'
+                })
+            }
+
+        })
+        .catch(err => {
+            res.status(500).json({
+                status: 500,
+                error: err
+            });
+        })
+}
 
 exports.log_application = (req, res, next) => {
     const application = new Application ({

--- a/api/controllers/applicationsController.js
+++ b/api/controllers/applicationsController.js
@@ -304,6 +304,23 @@ exports.delete_application = (req, res, next) => {
         });
 }
 
+exports.delete_applications_by_user_id = (req, res, next) => {
+    const id = req.params.userId;
+    Application
+        .deleteMany({ user_id: id })
+        .exec()
+        .then(result => {
+            res.status(200).json({
+                status: 200,
+                user_id: id,
+                message: `Deleted ${result.deletedCount}`
+            })
+        })
+        .catch(err => {
+            res.status(500).json({ error: err })
+        });
+}
+
 exports.delete_applications = (req, res, next) => {
     let deleteTest = req.body.deleteTest;
     console.log(deleteTest)

--- a/api/controllers/applicationsController.js
+++ b/api/controllers/applicationsController.js
@@ -13,6 +13,7 @@ exports.get_all_applications = (req, res, next) => {
                     return {
                         _id: doc._id,
                         TEST_application: doc.TEST_application,
+                        user_id: doc.user_id,
                         session_id: doc.session_id,
                         session_date: doc.session_date,
                         session_time: doc.session_time,
@@ -67,6 +68,7 @@ exports.get_by_session_id = (req, res, next) => {
                     return {
                         _id: doc._id,
                         TEST_application: doc.TEST_application,
+                        user_id: doc.u,
                         session_id: doc.session_id,
                         session_date: doc.session_date,
                         session_time: doc.session_time,
@@ -112,6 +114,7 @@ exports.log_application = (req, res, next) => {
     const application = new Application ({
         _id: new mongoose.Types.ObjectId(),
         TEST_application: req.body.TEST_application,
+        user_id: req.body.user_id,
         session_id: req.body.session_id,
         session_date: req.body.session_date,
         session_time: req.body.session_time,
@@ -141,6 +144,7 @@ exports.log_application = (req, res, next) => {
                 loggedApplication: {
                     _id: result._id,
                     TEST_application: result.TEST_application,
+                    user_id: result.user_id,
                     session_id: result.session_id,
                     session_date: result.session_date,
                     session_time: result.session_time,
@@ -185,6 +189,7 @@ exports.get_application = (req, res, next) => {
                 res.status(200).json({
                     _id: doc._id,
                     TEST_application: doc.TEST_application,
+                    user_id: doc.user_id,
                     session_id: doc.session_id,
                     session_date: doc.session_date,
                     session_time: doc.session_time,

--- a/api/controllers/applicationsController.js
+++ b/api/controllers/applicationsController.js
@@ -12,7 +12,6 @@ exports.get_all_applications = (req, res, next) => {
                 applications: docs.map(doc => {
                     return {
                         _id: doc._id,
-                        TEST_application: doc.TEST_application,
                         user_id: doc.user_id,
                         session_id: doc.session_id,
                         session_date: doc.session_date,
@@ -67,7 +66,6 @@ exports.get_by_session_id = (req, res, next) => {
                 applications: docs.map(doc => {
                     return {
                         _id: doc._id,
-                        TEST_application: doc.TEST_application,
                         user_id: doc.user_id,
                         session_id: doc.session_id,
                         session_date: doc.session_date,
@@ -122,7 +120,6 @@ exports.get_by_user_id = (req, res, next) => {
                 applications: docs.map(doc => {
                     return {
                         _id: doc._id,
-                        TEST_application: doc.TEST_application,
                         user_id: doc.user_id,
                         session_id: doc.session_id,
                         session_date: doc.session_date,
@@ -168,7 +165,6 @@ exports.get_by_user_id = (req, res, next) => {
 exports.log_application = (req, res, next) => {
     const application = new Application ({
         _id: new mongoose.Types.ObjectId(),
-        TEST_application: req.body.TEST_application,
         user_id: req.body.user_id,
         session_id: req.body.session_id,
         session_date: req.body.session_date,
@@ -198,7 +194,6 @@ exports.log_application = (req, res, next) => {
                 message: "Application successfully logged",
                 loggedApplication: {
                     _id: result._id,
-                    TEST_application: result.TEST_application,
                     user_id: result.user_id,
                     session_id: result.session_id,
                     session_date: result.session_date,
@@ -243,7 +238,6 @@ exports.get_application = (req, res, next) => {
             if (doc) {
                 res.status(200).json({
                     _id: doc._id,
-                    TEST_application: doc.TEST_application,
                     user_id: doc.user_id,
                     session_id: doc.session_id,
                     session_date: doc.session_date,
@@ -319,32 +313,4 @@ exports.delete_applications_by_user_id = (req, res, next) => {
         .catch(err => {
             res.status(500).json({ error: err })
         });
-}
-
-exports.delete_applications = (req, res, next) => {
-    let deleteTest = req.body.deleteTest;
-    console.log(deleteTest)
-    if (deleteTest) {
-        Application
-            .deleteMany({ "TEST_application": true })
-            .exec()
-            .then(result => {
-                res.status(200).json({
-                    status: 200,
-                    message: `Deleted ${result.deletedCount}`
-                })
-            })
-            .catch(err => {
-                res.status(500).json({
-                    status: 500,
-                    error: err
-                })
-            })
-    } else {
-        res.status(500).json({
-            status: 500,
-            message: 'Delete test applications set to false. No applications deleted'
-        })
-    }
-
 }

--- a/api/controllers/sessionsController.js
+++ b/api/controllers/sessionsController.js
@@ -12,7 +12,6 @@ exports.get_all_sessions = (req, res, next) => {
                 sessions: docs.map(doc => {
                     return {
                         _id: doc._id,
-                        TEST_SESSION: doc.TEST_SESSION,
                         user_id: doc.user_id,
                         session_id: doc.session_id,
                         session_date: doc.session_date,
@@ -59,7 +58,6 @@ exports.get_session = (req, res, next) => {
             if (doc) {
                 res.status(200).json({
                     _id: doc._id,
-                    TEST_SESSION: doc.TEST_SESSION,
                     user_id: doc.user_id,
                     session_id: doc.session_id,
                     session_date: doc.session_date,
@@ -95,7 +93,6 @@ exports.get_session = (req, res, next) => {
 exports.log_session = (req, res, next) => {
     const session = new Session ({
         _id: new mongoose.Types.ObjectId(),
-        TEST_SESSION: req.body.TEST_SESSION,
         user_id: req.body.user_id,
         session_id: req.body.session_id,
         session_date: req.body.session_date,
@@ -122,7 +119,6 @@ exports.log_session = (req, res, next) => {
                 message: "Session successfully logged",
                 loggedSession: {
                     _id: result._id,
-                    TEST_SESSION: result.TEST_SESSION,
                     user_id: result.user_id,
                     session_id: result.session_id,
                     session_date: result.session_date,

--- a/api/controllers/sessionsController.js
+++ b/api/controllers/sessionsController.js
@@ -13,6 +13,7 @@ exports.get_all_sessions = (req, res, next) => {
                     return {
                         _id: doc._id,
                         TEST_SESSION: doc.TEST_SESSION,
+                        user_id: doc.user_id,
                         session_id: doc.session_id,
                         session_date: doc.session_date,
                         session_time: doc.session_time,
@@ -59,6 +60,7 @@ exports.get_session = (req, res, next) => {
                 res.status(200).json({
                     _id: doc._id,
                     TEST_SESSION: doc.TEST_SESSION,
+                    user_id: doc.user_id,
                     session_id: doc.session_id,
                     session_date: doc.session_date,
                     session_time: doc.session_time,
@@ -94,6 +96,7 @@ exports.log_session = (req, res, next) => {
     const session = new Session ({
         _id: new mongoose.Types.ObjectId(),
         TEST_SESSION: req.body.TEST_SESSION,
+        user_id: req.body.user_id,
         session_id: req.body.session_id,
         session_date: req.body.session_date,
         session_time: req.body.session_time,
@@ -120,6 +123,7 @@ exports.log_session = (req, res, next) => {
                 loggedSession: {
                     _id: result._id,
                     TEST_SESSION: result.TEST_SESSION,
+                    user_id: result.user_id,
                     session_id: result.session_id,
                     session_date: result.session_date,
                     session_time: result.session_time,

--- a/api/controllers/users.js
+++ b/api/controllers/users.js
@@ -16,6 +16,8 @@ exports.users_sign_up = (req, res, next) => {
                         } else {
                             const user = new User({
                                 _id: new mongoose.Types.ObjectId(),
+                                first_name: req.body.first_name,
+                                last_name: req.body.last_name,
                                 email: req.body.email,
                                 password: hash
                             });
@@ -23,7 +25,15 @@ exports.users_sign_up = (req, res, next) => {
                                 .save()
                                 .then(result => {
                                   console.log(result)
-                                  res.status(201).json({ message: 'User created' })
+                                  res.status(201).json({
+                                      message: 'User created',
+                                      user: {
+                                          _id: result._id,
+                                          first_name: result.first_name,
+                                          last_name: result.last_name,
+                                          email: result.email
+                                      }
+                                  })
                                 })
                                 .catch(err => {
                                   res.status(500).json({ error: err })

--- a/api/jada_functions.js
+++ b/api/jada_functions.js
@@ -95,7 +95,7 @@ exports.populate_potential_jobs = async function() {
     return additionalJobs;
 }
 
-async function isInterested(jobId, dkw, udkw, session_id, session_date, session_time) {
+async function isInterested(jobId, dkw, udkw, user_id, session_id, session_date, session_time) {
     let jobTitle = await driver.findElement({ xpath: '//*[@id="' + jobId + '"]/div/div/div[1]/a/h2'}).getText();
     let jobTitleWebElement = await driver.findElement({ xpath: '//*[@id="' + jobId + '"]'});
     let jobTitleClasses = await jobTitleWebElement.getAttribute('class');
@@ -115,6 +115,7 @@ async function isInterested(jobId, dkw, udkw, session_id, session_date, session_
         return true
     } else {
         let logFailedInterest = await log_failed_interest(
+            user_id,
             session_id,
             session_date,
             session_time,
@@ -126,7 +127,7 @@ async function isInterested(jobId, dkw, udkw, session_id, session_date, session_
     }
 }
 
-exports.check_interest = async function(potentialJobs, dkw, udkw, session_id, session_date, session_time) {
+exports.check_interest = async function(potentialJobs, dkw, udkw, user_id, session_id, session_date, session_time) {
     console.log('-------> checking job initial interest: <-------')
     let interestedRoles = [];
     let viewedResults = await get_applied_jobIds();
@@ -136,7 +137,15 @@ exports.check_interest = async function(potentialJobs, dkw, udkw, session_id, se
         console.log(`Current job id: ${potentialJobs[i]}`)
         console.log(`Has been viewed: ${hasBeenViewed}`)
         if (!hasBeenViewed) {
-            let interested = await isInterested(potentialJobs[i], dkw, udkw, session_id, session_date, session_time)
+            let interested = await isInterested(
+                potentialJobs[i],
+                dkw,
+                udkw,
+                user_id,
+                session_id,
+                session_date,
+                session_time
+            );
             console.log('/---- Interested: ')
             console.log(interested)
             if (interested) {
@@ -432,14 +441,16 @@ async function handle_fetch(url, requestMethod, dataToSend) {
     } else if (responseData.status === 500) {
         console.log('SESSION ERROR: handle fetch unsuccessful');
         console.log(`Response status: ${responseData.status}`);
-        console.log(`Response message: ${responseData.message}`);
+        console.log(`Response error:`);
+        console.log(responseData.error)
     }
     return responseData
 }
 
-async function log_failed_interest(session_id, session_date, session_time, jobId, jobTitle, keyWordFinder) {
+async function log_failed_interest(user_id, session_id, session_date, session_time, jobId, jobTitle, keyWordFinder) {
     let currentApplication = {
         "TEST_application": true,
+        "user_id": user_id,
         "session_id": session_id,
         "session_date": session_date,
         "session_time": session_time,
@@ -459,9 +470,10 @@ async function log_failed_interest(session_id, session_date, session_time, jobId
     }
 }
 
-async function log_undesirable_job(session_id, session_date, session_time, jobAdd, keyWordFinder) {
+async function log_undesirable_job(user_id, session_id, session_date, session_time, jobAdd, keyWordFinder) {
     let currentApplication = {
         "TEST_application": true,
+        "user_id": user_id,
         "session_id": session_id,
         "session_date": session_date,
         "session_time": session_time,
@@ -483,9 +495,10 @@ async function log_undesirable_job(session_id, session_date, session_time, jobAd
     }
 }
 
-async function log_desirable_job(session_id, session_date, session_time, jobAdd, keyWordFinder, appliedJob) {
+async function log_desirable_job(user_id, session_id, session_date, session_time, jobAdd, keyWordFinder, appliedJob) {
     let currentApplication = {
         "TEST_application": true,
+        "user_id": user_id,
         "session_id": session_id,
         "session_date": session_date,
         "session_time": session_time,
@@ -571,7 +584,7 @@ async function apply_to_job() {
     }
 }
 
-async function process_jobAdd(jobId, previouslyAppliedJobs, dkw, udkw, session_id, session_date, session_time) {
+async function process_jobAdd(jobId, previouslyAppliedJobs, dkw, udkw, user_id, session_id, session_date, session_time) {
     console.log('************************************************');
     let mainWindow = await driver.getWindowHandle();
     let appliedJob = false;
@@ -619,6 +632,7 @@ async function process_jobAdd(jobId, previouslyAppliedJobs, dkw, udkw, session_i
         let applyToJob = await apply_to_job();
         appliedJob = applyToJob;
         let logDesirableJob = await log_desirable_job(
+            user_id,
             session_id,
             session_date,
             session_time,
@@ -628,6 +642,7 @@ async function process_jobAdd(jobId, previouslyAppliedJobs, dkw, udkw, session_i
         );
     } else {
         let logUndesirableJob = await log_undesirable_job(
+            user_id,
             session_id,
             session_date,
             session_time,
@@ -657,9 +672,10 @@ async function get_all_applications() {
         console.log(`Response message: ${responseData.message}`);
         return [];
     } else if (responseData.status === 500) {
-        console.log('SESSION ERROR: handle fetch unsuccessful');
+        console.log('SESSION ERROR: handle fetch unsuccessful for all applications');
         console.log(`Response status: ${responseData.status}`);
-        console.log(`Response message: ${responseData.message}`);
+        console.log(`Response error:`);
+        console.log(responseData.error)
     }
 
     let applications = await responseData.response.applications;
@@ -677,7 +693,7 @@ async function get_applied_jobIds() {
     return processedIds
 }
 
-exports.process_interested_jobs = async function(interestedJobIds, dkw, udkw, session_id, session_date, session_time) {
+exports.process_interested_jobs = async function(interestedJobIds, dkw, udkw, user_id, session_id, session_date, session_time) {
     console.log('--------> processing interested jobs: <--------')
     let appliedJobs = [];
     let previouslyAppliedJobs = await get_applied_jobIds();
@@ -689,6 +705,7 @@ exports.process_interested_jobs = async function(interestedJobIds, dkw, udkw, se
             previouslyAppliedJobs,
             dkw,
             udkw,
+            user_id,
             session_id,
             session_date,
             session_time
@@ -786,9 +803,10 @@ async function get_by_sessionId(sessionId) {
         console.log(`Response message: ${responseData.message}`);
         return [];
     } else if (responseData.status === 500) {
-        console.log('SESSION ERROR: handle fetch unsuccessful');
+        console.log('SESSION ERROR: handle fetch unsuccessful by session Id');
         console.log(`Response status: ${responseData.status}`);
-        console.log(`Response message: ${responseData.message}`);
+        console.log(`Response error:`);
+        console.log(responseData.error)
     }
 
     let applications = await responseData.response.applications;
@@ -848,7 +866,7 @@ function remove_duplicates(array) {
         unique.includes(item) ? unique : [...unique, item],[]);
 }
 
-exports.produce_session_report = async function(session_id, session_date, session_time, allSessionJobIds) {
+exports.produce_session_report = async function(user_id, session_id, session_date, session_time, allSessionJobIds) {
     let applications = await get_by_sessionId(session_id)
     let successfullyApplied = applications.filter((application) => {
         if (application.apply_attempted === true) {
@@ -874,6 +892,7 @@ exports.produce_session_report = async function(session_id, session_date, sessio
 
     return {
         "TEST_SESSION": true,
+        "user_id": user_id,
         "session_id": session_id,
         "session_date": session_date,
         "session_time": session_time,
@@ -892,46 +911,6 @@ exports.produce_session_report = async function(session_id, session_date, sessio
     }
 }
 
-async function produce_all_sessions_report() {
-    let applications = await get_all_applications();
-    let successfullyApplied = applications.filter((application) => {
-        if (application.apply_attempted === true) {
-            return application
-        }
-    });
-
-    let skippedApplications = applications.filter((application) => {
-        if (application.apply_attempted === false) {
-            return application
-        }
-    })
-
-    let dkwFoundAll = map_dkw(applications);
-    let udkwFoundAll = map_udkw(applications);
-    let top24FoundAll = map_top24(applications);
-    let locationsAll = map_locations(applications);
-
-    let dkwFoundUnique = remove_duplicates(dkwFoundAll);
-    let udkwFoundUnique = remove_duplicates(udkwFoundAll);
-    let top24FoundUnique = remove_duplicates(top24FoundAll);
-    let locationsOverview = remove_duplicates(locationsAll);
-
-    return {
-        "TEST_SESSION": true,
-        "total_processed": applications.length,
-        "total_applied": successfullyApplied.length,
-        "total_skipped": skippedApplications.length,
-        "total_dkw_overview": dkwFoundUnique,
-        "total_dkw_all": dkwFoundAll,
-        "total_udkw_overview":udkwFoundUnique,
-        "total_udkw_all": udkwFoundAll,
-        "total_top24_overview": top24FoundUnique,
-        "total_top24_all": top24FoundAll,
-        "total_locations_overview": locationsOverview,
-        "total_locations_all" : locationsAll
-    }
-}
-
 exports.save_session = async function(sessionReport) {
     let responseData = await handle_fetch(
         'http://localhost:8080/sessions',
@@ -940,7 +919,7 @@ exports.save_session = async function(sessionReport) {
     )
 
     if (responseData.status !== 200) {
-        console.log(`SESSION ERROR: unable to log job id: ${sessionReport.session_id}`)
+        console.log(`SESSION ERROR: unable to log session id: ${sessionReport.session_id}`)
         return false
     } else if (responseData.status === 200) {
         console.log('Successfully logged session report...')
@@ -1029,7 +1008,6 @@ function display_email_keyWords(kwOverview, kwAll) {
 }
 
 exports.email_session_report = async function(searchParams, sessionReport) {
-    let allSessionsReport = await produce_all_sessions_report();
     let transporter = nodeMailer.createTransport({
         service: 'gmail',
         auth: {
@@ -1052,6 +1030,7 @@ exports.email_session_report = async function(searchParams, sessionReport) {
             <p>Radius: ${searchParams.radius}</p>
             
             <h3>Session results:</h3>
+            <p>User Id: ${sessionReport.user_id}</p>
             <p>Session Id: ${sessionReport.session_id}</p>
             <p>Session date: ${sessionReport.session_date}</p>
             <p>Session time: ${sessionReport.session_time}</p>

--- a/api/jada_functions.js
+++ b/api/jada_functions.js
@@ -449,7 +449,6 @@ async function handle_fetch(url, requestMethod, dataToSend) {
 
 async function log_failed_interest(user_id, session_id, session_date, session_time, jobId, jobTitle, keyWordFinder) {
     let currentApplication = {
-        "TEST_application": true,
         "user_id": user_id,
         "session_id": session_id,
         "session_date": session_date,
@@ -472,7 +471,6 @@ async function log_failed_interest(user_id, session_id, session_date, session_ti
 
 async function log_undesirable_job(user_id, session_id, session_date, session_time, jobAdd, keyWordFinder) {
     let currentApplication = {
-        "TEST_application": true,
         "user_id": user_id,
         "session_id": session_id,
         "session_date": session_date,
@@ -497,7 +495,6 @@ async function log_undesirable_job(user_id, session_id, session_date, session_ti
 
 async function log_desirable_job(user_id, session_id, session_date, session_time, jobAdd, keyWordFinder, appliedJob) {
     let currentApplication = {
-        "TEST_application": true,
         "user_id": user_id,
         "session_id": session_id,
         "session_date": session_date,
@@ -915,7 +912,6 @@ exports.produce_session_report = async function(user_id, session_id, session_dat
     let locationsOverview = remove_duplicates(locationsAll);
 
     return {
-        "TEST_SESSION": true,
         "user_id": user_id,
         "session_id": session_id,
         "session_date": session_date,

--- a/api/models/applicationModel.js
+++ b/api/models/applicationModel.js
@@ -2,7 +2,6 @@ const mongoose = require('mongoose');
 
 const applicationSchema = mongoose.Schema({
     _id: mongoose.Schema.Types.ObjectId,
-    TEST_application: { type: Boolean, required: true},
     user_id: { type: String, required: true },
     obj_date: { type: Date, default: Date.now() },
     session_id: { type: String, required: true },

--- a/api/models/applicationModel.js
+++ b/api/models/applicationModel.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const applicationSchema = mongoose.Schema({
     _id: mongoose.Schema.Types.ObjectId,
     TEST_application: { type: Boolean, required: true},
+    user_id: { type: String, required: true },
     obj_date: { type: Date, default: Date.now() },
     session_id: { type: String, required: true },
     session_date: { type: String, required: true },

--- a/api/models/sessionModel.js
+++ b/api/models/sessionModel.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const sessionSchema = mongoose.Schema({
     _id: mongoose.Schema.Types.ObjectId,
     TEST_SESSION: { type: Boolean, required: true},
+    user_id: { type: String, required: true },
     session_id: { type: String, required: true },
     session_date: { type: String, required: true },
     session_time: { type: String, required: true },

--- a/api/models/sessionModel.js
+++ b/api/models/sessionModel.js
@@ -2,7 +2,6 @@ const mongoose = require('mongoose');
 
 const sessionSchema = mongoose.Schema({
     _id: mongoose.Schema.Types.ObjectId,
-    TEST_SESSION: { type: Boolean, required: true},
     user_id: { type: String, required: true },
     session_id: { type: String, required: true },
     session_date: { type: String, required: true },

--- a/api/models/user.js
+++ b/api/models/user.js
@@ -2,6 +2,8 @@ const mongoose = require('mongoose');
 
 const userSchema = mongoose.Schema({
     _id: mongoose.Schema.Types.ObjectId,
+    first_name: { type: String, required: true },
+    last_name: { type: String, required: true },
     email: {
         type: String,
         required: true,

--- a/api/routes/applications.js
+++ b/api/routes/applications.js
@@ -3,9 +3,10 @@ const router = express.Router();
 const applicationsController = require('../controllers/applicationsController');
 
 router.get('/', applicationsController.get_all_applications);
-router.post('/', applicationsController.log_application);
 router.get('/:applicationId', applicationsController.get_application);
 router.get('/session/:sessionId', applicationsController.get_by_session_id);
+router.get('/user/:userId', applicationsController.get_by_user_id);
+router.post('/', applicationsController.log_application);
 router.delete('/:applicationId', applicationsController.delete_application);
 router.delete('/', applicationsController.delete_applications);
 

--- a/api/routes/applications.js
+++ b/api/routes/applications.js
@@ -9,6 +9,5 @@ router.get('/user/:userId', applicationsController.get_by_user_id);
 router.post('/', applicationsController.log_application);
 router.delete('/:applicationId', applicationsController.delete_application);
 router.delete('/user/:userId', applicationsController.delete_applications_by_user_id);
-router.delete('/', applicationsController.delete_applications);
 
 module.exports = router;

--- a/api/routes/applications.js
+++ b/api/routes/applications.js
@@ -8,6 +8,7 @@ router.get('/session/:sessionId', applicationsController.get_by_session_id);
 router.get('/user/:userId', applicationsController.get_by_user_id);
 router.post('/', applicationsController.log_application);
 router.delete('/:applicationId', applicationsController.delete_application);
+router.delete('/user/:userId', applicationsController.delete_applications_by_user_id);
 router.delete('/', applicationsController.delete_applications);
 
 module.exports = router;

--- a/api/run_jada.js
+++ b/api/run_jada.js
@@ -17,14 +17,16 @@ const udkw = [
 const jobTitle = 'Junior Software Engineer';
 const area = 'Kent';
 const radius = 0;
+const userId = 'obj_id'
 
-run_jada(jobTitle, area, radius);
+run_jada(userId, jobTitle, area, radius);
 
-async function run_jada(jobTitle, area, radius) {
+async function run_jada(userId, jobTitle, area, radius) {
+    console.log(`User Id: ${userId}`)
     console.log(`Job Title: ${jobTitle}`)
     console.log(`Area: ${area}`)
     console.log(`Radius: ${radius}`)
-    let searchParams = { "job_title": jobTitle, "location": area, "radius": radius }
+    let searchParams = { "user_id": userId, "job_title": jobTitle, "location": area, "radius": radius }
     const radiusOptions = [0, 5, 10, 20, 30];
     let session_date = Jada.getDate('-')
     let session_id = Jada.getDate('') + mongoose.Types.ObjectId();

--- a/api/run_jada.js
+++ b/api/run_jada.js
@@ -15,18 +15,18 @@ const udkw = [
 
 // BEFORE RUNNING <---> SWITCH FROM TEST BUILD USING CL
 const jobTitle = 'Junior Software Engineer';
-const area = 'Kent';
+const area = 'Dorset';
 const radius = 0;
-const userId = 'obj_id'
+const user_id = '5f102df825d2553212c30ede'
 
-run_jada(userId, jobTitle, area, radius);
+run_jada(user_id, jobTitle, area, radius);
 
-async function run_jada(userId, jobTitle, area, radius) {
-    console.log(`User Id: ${userId}`)
+async function run_jada(user_id, jobTitle, area, radius) {
+    console.log(`User Id: ${user_id}`)
     console.log(`Job Title: ${jobTitle}`)
     console.log(`Area: ${area}`)
     console.log(`Radius: ${radius}`)
-    let searchParams = { "user_id": userId, "job_title": jobTitle, "location": area, "radius": radius }
+    let searchParams = { "user_id": user_id, "job_title": jobTitle, "location": area, "radius": radius }
     const radiusOptions = [0, 5, 10, 20, 30];
     let session_date = Jada.getDate('-')
     let session_id = Jada.getDate('') + mongoose.Types.ObjectId();
@@ -64,6 +64,7 @@ async function run_jada(userId, jobTitle, area, radius) {
             potentialJobsIds,
             dkw,
             udkw,
+            user_id,
             session_id,
             session_date,
             session_time
@@ -77,6 +78,7 @@ async function run_jada(userId, jobTitle, area, radius) {
             interestedJobIds,
             dkw,
             udkw,
+            user_id,
             session_id,
             session_date,
             session_time
@@ -95,7 +97,13 @@ async function run_jada(userId, jobTitle, area, radius) {
 
     } while (activeNextBtn)
 
-    let sessionReport = await Jada.produce_session_report(session_id, session_date, session_time, allSessionJobIds);
+    let sessionReport = await Jada.produce_session_report(
+        user_id,
+        session_id,
+        session_date,
+        session_time,
+        allSessionJobIds
+    );
     let savedSessionReport = await Jada.save_session(sessionReport)
 
     if (savedSessionReport) {

--- a/api/run_jada.js
+++ b/api/run_jada.js
@@ -17,7 +17,7 @@ const udkw = [
 const jobTitle = 'Junior Software Engineer';
 const area = 'Dorset';
 const radius = 0;
-const user_id = '5f102df825d2553212c30ede'
+const user_id = '5f102df825d2553212c30ede';
 
 run_jada(user_id, jobTitle, area, radius);
 

--- a/jada-app/src/Components/Pages/MainDashboard/MainDashboard.js
+++ b/jada-app/src/Components/Pages/MainDashboard/MainDashboard.js
@@ -21,6 +21,7 @@ class MainDashboard extends React.Component {
         super(props);
 
         this.state = {
+            user_id: "5f102df825d2553212c30ede",
             applications: {},
             sessionDates:[]
         }
@@ -55,7 +56,7 @@ class MainDashboard extends React.Component {
     }
 
     fetchApplications = async () => {
-        const url = 'http://localhost:8080/applications/';
+        const url = `http://localhost:8080/applications/user/${this.state.user_id}`;
         let data = await fetch(url, {
             method: 'GET',
             headers: {

--- a/jada-app/src/Components/Pages/TablesPage/TablesPage.js
+++ b/jada-app/src/Components/Pages/TablesPage/TablesPage.js
@@ -11,6 +11,7 @@ class TablesPage extends React.Component {
         super(props);
 
         this.state = {
+            user_id: "5f102df825d2553212c30ede",
             applications: {},
             currentApplications: {},
             sessionDates:[]
@@ -49,7 +50,7 @@ class TablesPage extends React.Component {
     }
 
     fetchApplications = async () => {
-        const url = 'http://localhost:8080/applications/';
+        const url = `http://localhost:8080/applications/user/${this.state.user_id}`;
         let data = await fetch(url, {
             method: 'GET',
             headers: {


### PR DESCRIPTION
Added functionality to store applications with user_id and added api route to get and delete by `user_id`

Amended: 
- `applicationsController` : removed `TEST_application` from all methods, added `user_id` property, added `get_by_user_id` method, added `delete_by_user_id` method.
- `sessionsController` : removed `TEST_SESSION` property from all methods, added `user_id` property to all methods
- `users.js` _CONTROLLER_ : added first and last name properties to user controller
- `jada_functions` : corrected error printing, passing and using `user_id` in all the following:
    - `isInterested()`
    - `log_failed_interest()`
    - `check_interest()`
    - `get_applied_jobIds()`
    - `log_undesirable_job()`
    - `log_desirable_job()`
    - `process_jobAdd()`
    - `log_failed_interest()`
    - `process_interested_jobs()`
    - `produce_session_report()`
    - `email_session_report()`
- `applicationModel.js` : removed `TEST_application` and required in `user_id`
- `sessionModel` : removed `TEST_SESSION` and required in `user_id`
- `user.js` _MODEL_ : added and required in `first_name` and `last_name`
- `applications.js` _ROUTE_ : added `/user/:userId` route to get all applications by user id
- `jada_functions` : got rid of `get_all_applications()` method, and replaced with `get_applications_by_user_id()` for better processing time
- `run_jada.js` : added `user_id` variable, passing through `run_jada()` function
- `MainDashboard` Component : manually setting `user_id` in state and changed fetch to get by user id
- `TablesPage` Component : manually setting `user_id` in state and changed fetch to get by user id
