### PR TITLE
E3 06.3 run job search

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -478,9 +478,6 @@ These routes delete applications from the DB.
 - GET `/api/sessions/:sessionId` : returns a single session
 - POST `/api/sessions/` : logs a session to DB
 
-- Runtime logic:
-    - POST `/api/sessions/totalJobsLogIn` : navigates to totalJobs and logs in
-
 ### GET
 **/api/sessions/**
 
@@ -635,3 +632,50 @@ You must be authenticated to get data from this route; requires token.
           "error": "Relevant error message"
         }
     
+## SYSTEM RUNTIME LOGIC (via sessions route)
+
+- POST `/api/sessions/totalJobsLogIn` : navigates to totalJobs and logs in
+
+
+- You must be authenticated to call this route; requires bearer token.
+- If authentication passes and log in details accepted, route successfully logs in the user's totalJobs account and lands on totalJobs homepage 
+
+- Email and encoded password required (example):
+    ```JSON
+      {
+        "email": "joe@blogs.com",
+        "encPss": "5efdbddc2b498306b5f98de8"
+      }
+  
+- Returns:
+  - if successful (example) :
+      ```JSON
+        {
+          "status": 200,
+          "message": "Session successfully logged",
+          "loggedSession": { 
+            "_id": "5efdbddc2b498306b5f98de8",
+            "session_id": "202007025efdbdc0c3f14b06b7710f5e",
+            "session_date": "2020-07-02",
+            "session_time": "11:58:08",
+            "total_processed": 20,
+            "newly_processed": 8,
+            "successfully_applied": 3,
+            "skipped_applications": 5,
+            "dkw_overview": ["DEVELOPER", "SOFTWARE", "ENGINEER", "GRADUATE"],
+            "dkw_all": ["DEVELOPER", "SOFTWARE", "ENGINEER", "DEVELOPER", "GRADUATE", "ENGINEER", "GRADUATE"],
+            "udkw_overview": ["TRAINEESHIP", "CONSULTANT", "LEAD"],
+            "udkw_all": ["TRAINEESHIP", "CONSULTANT", "LEAD", "LEAD"],
+            "top24_overview": ["JAVA", "SCALA"],
+            "top24_all": ["JAVA", "SCALA", "JAVA", "JAVA"],
+            "locations_overview": ["UK", "MOUNT"],
+            "locations_all": ["UK", "MOUNT", "MOUNT", "UK"]
+        }
+      }
+  - if unsuccessful
+      ```JSON
+        { 
+          "status": 500,
+          "success": false, 
+          "error": "Relevant error message"
+        }

--- a/api/README.md
+++ b/api/README.md
@@ -656,13 +656,13 @@ You must be authenticated to get data from this route; requires token.
           "success": true,
           "message": "Successfully logged into totalJobs account"
         }
-  - if validation unsuccessful, i.e. `status: 400`
+  - if validation unsuccessful, i.e. `{ status: 400, success: false, message: "Invalid email" }` 
       ```JSON
         { 
           "success": false, 
           "error": "Relevant 400 error message"
         }
-  - if connection unsuccessful, i.e. `status: 500, success: false, message: "Invalid email"` 
+  - if connection unsuccessful
       ```JSON
         { 
           "success": false, 

--- a/api/README.md
+++ b/api/README.md
@@ -634,10 +634,13 @@ You must be authenticated to get data from this route; requires token.
     
     
     
-## SYSTEM RUNTIME LOGIC (via sessions route)
+## SYSTEM SESSION RUNTIME LOGIC (via sessions route)
 
 - POST `/api/sessions/totalJobsLogIn` : navigates to totalJobs and logs in
+- POST `/api/sessions/runJobSearch` : enters given search preferences and lands on results page
 
+### POST
+**/api/sessions/totalJobsLogIn**
 
 - You must be authenticated to call this route; requires bearer token.
 - If authentication passes and log in details accepted, route successfully logs in the user's totalJobs account and lands on totalJobs homepage 
@@ -667,4 +670,48 @@ You must be authenticated to get data from this route; requires token.
         { 
           "success": false, 
           "error": "Relevant error message"
+        }
+    
+### POST
+**/api/sessions/runJobSearch**
+
+- You must be authenticated to call this route; requires bearer token.
+- If authentication passes and search parameters accepted, route applies search preferences and lands on totalJobs result page
+
+- The route requires a job title, location and radius
+- The route also requires to be on the correct url. Page title must match `Jobs | UK Job Search | Find your perfect job - totaljobs` otherwise returns system error and exits execution
+- Job title and location must be strings
+- Radius must be a number and either be; 0, 5, 10, 20 or 30
+- An example request:
+    ```JSON
+      {
+        "job_title": "Junior Software Engineer",
+        "location": "Bristol",
+        "radius": 5
+      }
+  
+- Returns: 
+  - if successful, once navigation finished executing (example) :
+      ```JSON
+        {
+          "success": true,
+          "search": {
+            "job_title": "Junior Software Engineer",
+            "location": "Bristol",
+            "radius": 20
+          },
+          "message": "Successfully entered search and found results"
+        }
+  - if validation unsuccessful (example)
+      ```JSON
+        { 
+          "success": false,
+          "message": "Incorrect radius number",
+          "expected_options": [0, 5, 10, 20, 30]
+        }
+  - if connection unsuccessful
+      ```JSON
+        { 
+          "success": false,
+          "message": "system error"
         }

--- a/api/README.md
+++ b/api/README.md
@@ -632,6 +632,8 @@ You must be authenticated to get data from this route; requires token.
           "error": "Relevant error message"
         }
     
+    
+    
 ## SYSTEM RUNTIME LOGIC (via sessions route)
 
 - POST `/api/sessions/totalJobsLogIn` : navigates to totalJobs and logs in
@@ -647,35 +649,22 @@ You must be authenticated to get data from this route; requires token.
         "encPss": "5efdbddc2b498306b5f98de8"
       }
   
-- Returns:
-  - if successful (example) :
+- Returns: 
+  - if successful, once navigation finished executing (example) :
       ```JSON
         {
-          "status": 200,
-          "message": "Session successfully logged",
-          "loggedSession": { 
-            "_id": "5efdbddc2b498306b5f98de8",
-            "session_id": "202007025efdbdc0c3f14b06b7710f5e",
-            "session_date": "2020-07-02",
-            "session_time": "11:58:08",
-            "total_processed": 20,
-            "newly_processed": 8,
-            "successfully_applied": 3,
-            "skipped_applications": 5,
-            "dkw_overview": ["DEVELOPER", "SOFTWARE", "ENGINEER", "GRADUATE"],
-            "dkw_all": ["DEVELOPER", "SOFTWARE", "ENGINEER", "DEVELOPER", "GRADUATE", "ENGINEER", "GRADUATE"],
-            "udkw_overview": ["TRAINEESHIP", "CONSULTANT", "LEAD"],
-            "udkw_all": ["TRAINEESHIP", "CONSULTANT", "LEAD", "LEAD"],
-            "top24_overview": ["JAVA", "SCALA"],
-            "top24_all": ["JAVA", "SCALA", "JAVA", "JAVA"],
-            "locations_overview": ["UK", "MOUNT"],
-            "locations_all": ["UK", "MOUNT", "MOUNT", "UK"]
+          "success": true,
+          "message": "Successfully logged into totalJobs account"
         }
-      }
-  - if unsuccessful
+  - if validation unsuccessful, i.e. `status: 400`
       ```JSON
         { 
-          "status": 500,
+          "success": false, 
+          "error": "Relevant 400 error message"
+        }
+  - if connection unsuccessful, i.e. `status: 500, success: false, message: "Invalid email"` 
+      ```JSON
+        { 
           "success": false, 
           "error": "Relevant error message"
         }

--- a/api/README.md
+++ b/api/README.md
@@ -659,7 +659,7 @@ You must be authenticated to get data from this route; requires token.
           "success": true,
           "message": "Successfully logged into totalJobs account"
         }
-  - if validation unsuccessful, i.e. `{ status: 400, success: false, message: "Invalid email" }` 
+  - if validation unsuccessful, i.e. `{ "status": 400, "success": false, "message": "Invalid email" }` 
       ```JSON
         { 
           "success": false, 

--- a/api/controllers/sessions/runJobSearch/runJobSearchActions.js
+++ b/api/controllers/sessions/runJobSearch/runJobSearchActions.js
@@ -1,0 +1,20 @@
+const localWebDriver = require('../webDriver');
+const driver = localWebDriver.get_driver();
+
+exports.enter_job_title = async (jobTitle) => {
+    try {
+        await driver.findElement({ id: 'keywords' }).sendKeys(jobTitle);
+    } catch (err) { throw err }
+}
+
+exports.enter_location = async (location) => {
+    try {
+        await driver.findElement({ id: 'location' }).sendKeys(location);
+    } catch (err) { throw err }
+}
+
+exports.enter_radius = async (radius) => {
+    try {
+        await driver.findElement({ id: 'LocationType' }).sendKeys(radius);
+    } catch (err) { throw err }
+}

--- a/api/controllers/sessions/runJobSearch/runJobSearchActions.js
+++ b/api/controllers/sessions/runJobSearch/runJobSearchActions.js
@@ -2,6 +2,11 @@ const WebDriver = require('selenium-webdriver');
 const localWebDriver = require('../webDriver');
 const driver = localWebDriver.get_driver();
 
+exports.valid_url = async () => {
+    let title = await driver.getTitle();
+    return title === 'Jobs | UK Job Search | Find your perfect job - totaljobs';
+}
+
 exports.enter_job_title = async (jobTitle) => {
     try {
         await driver.findElement({ id: 'keywords' }).clear();

--- a/api/controllers/sessions/runJobSearch/runJobSearchActions.js
+++ b/api/controllers/sessions/runJobSearch/runJobSearchActions.js
@@ -3,12 +3,14 @@ const driver = localWebDriver.get_driver();
 
 exports.enter_job_title = async (jobTitle) => {
     try {
+        await driver.findElement({ id: 'keywords' }).clear();
         await driver.findElement({ id: 'keywords' }).sendKeys(jobTitle);
     } catch (err) { throw err }
 }
 
 exports.enter_location = async (location) => {
     try {
+        await driver.findElement({ id: 'location' }).clear();
         await driver.findElement({ id: 'location' }).sendKeys(location);
     } catch (err) { throw err }
 }

--- a/api/controllers/sessions/runJobSearch/runJobSearchActions.js
+++ b/api/controllers/sessions/runJobSearch/runJobSearchActions.js
@@ -1,3 +1,4 @@
+const WebDriver = require('selenium-webdriver');
 const localWebDriver = require('../webDriver');
 const driver = localWebDriver.get_driver();
 
@@ -18,5 +19,14 @@ exports.enter_location = async (location) => {
 exports.enter_radius = async (radius) => {
     try {
         await driver.findElement({ id: 'LocationType' }).sendKeys(radius);
+    } catch (err) { throw err }
+}
+
+exports.click_search = async () => {
+    try {
+        await driver.findElement({ id: 'search-button' }).click();
+        await driver.wait(WebDriver.until.elementLocated({
+            xpath: '//*[@id="scroll-to-top"]'
+        }), 20000);
     } catch (err) { throw err }
 }

--- a/api/controllers/sessions/runJobSearch/runJobSearchController.js
+++ b/api/controllers/sessions/runJobSearch/runJobSearchController.js
@@ -1,5 +1,19 @@
-
+const { enter_job_title, enter_location, enter_radius } = require('../runJobSearch/runJobSearchActions');
 
 exports.enter_search = async (req, res, next) => {
-    res.status(200).json({ message: 'I hear ya!'})
+    const reqJobTitle = req.body.job_title;
+    const reqLocation = req.body.location;
+    const reqRadius = req.body.radius;
+
+    // validate and sanitize data
+
+    try {
+        await enter_job_title(reqJobTitle)
+        await enter_location(reqLocation)
+        await enter_radius(reqRadius)
+        await res.status(200).json({ message: 'I hear ya!'})
+    } catch (err) {
+        await res.status(500).json({ error: err })
+    }
+
 }

--- a/api/controllers/sessions/runJobSearch/runJobSearchController.js
+++ b/api/controllers/sessions/runJobSearch/runJobSearchController.js
@@ -1,3 +1,4 @@
+const { validate_type, sanitize_string } = require('../../../Entities/validationEntity')
 const { enter_job_title, enter_location, enter_radius } = require('../runJobSearch/runJobSearchActions');
 
 exports.enter_search = async (req, res, next) => {
@@ -5,15 +6,53 @@ exports.enter_search = async (req, res, next) => {
     const reqLocation = req.body.location;
     const reqRadius = req.body.radius;
 
-    // validate and sanitize data
+    if (!(validate_type(reqJobTitle, 'string')) ||
+        !(validate_type(reqLocation, 'string')) ||
+        !(validate_type(reqRadius, 'number'))) {
+        await res.status(400).json({
+            success: false,
+            message: 'Incorrect data types submitted',
+            expected_types: {
+                job_title: "string",
+                location: "string",
+                radius: "number"
+            }
+        })
+        return
+    }
+
+    const jobTitle = sanitize_string(reqJobTitle.trim());
+    const location = sanitize_string(reqLocation.trim());
+    let radiusOptions = [0, 5, 10, 20, 30];
+    let radiusValid = radiusOptions.includes(reqRadius);
+    if (!radiusValid) {
+        await res.status(400).json({
+            success: false,
+            message: 'Incorrect radius number',
+            expected_options: [0, 5, 10, 20, 30]
+        })
+        return
+    }
 
     try {
-        await enter_job_title(reqJobTitle)
-        await enter_location(reqLocation)
+        await enter_job_title(jobTitle)
+        await enter_location(location)
         await enter_radius(reqRadius)
-        await res.status(200).json({ message: 'I hear ya!'})
+        await res.status(200).json({
+            success: true,
+            search: {
+                job_title: jobTitle,
+                location: location,
+                radius: reqRadius
+            },
+            message: 'Successfully entered search and found results'
+        })
     } catch (err) {
-        await res.status(500).json({ error: err })
+        console.log(err)
+        await res.status(500).json({
+            success: false,
+            message: 'system error'
+        })
     }
 
 }

--- a/api/controllers/sessions/runJobSearch/runJobSearchController.js
+++ b/api/controllers/sessions/runJobSearch/runJobSearchController.js
@@ -1,6 +1,6 @@
 const { validate_type, sanitize_string } = require('../../../Entities/validationEntity')
 const { enter_job_title, enter_location,
-    enter_radius, click_search } = require('../runJobSearch/runJobSearchActions');
+    enter_radius, click_search, valid_url } = require('../runJobSearch/runJobSearchActions');
 
 exports.enter_search = async (req, res, next) => {
     const reqJobTitle = req.body.job_title;
@@ -13,7 +13,7 @@ exports.enter_search = async (req, res, next) => {
         await res.status(400).json({
             success: false,
             message: 'Incorrect data types submitted',
-            expected_types: {
+            expected: {
                 job_title: "string",
                 location: "string",
                 radius: "number"
@@ -33,6 +33,23 @@ exports.enter_search = async (req, res, next) => {
             expected_options: [0, 5, 10, 20, 30]
         })
         return
+    }
+
+    try {
+        let validUrl = await valid_url();
+        if (!validUrl) {
+            await res.status(500).json({
+                success: false,
+                message: 'System error; required system url not found'
+            })
+            return
+        }
+    } catch (err) {
+        console.log(err)
+        await res.status(500).json({
+            success: false,
+            message: 'system error'
+        })
     }
 
     try {

--- a/api/controllers/sessions/runJobSearch/runJobSearchController.js
+++ b/api/controllers/sessions/runJobSearch/runJobSearchController.js
@@ -1,5 +1,6 @@
 const { validate_type, sanitize_string } = require('../../../Entities/validationEntity')
-const { enter_job_title, enter_location, enter_radius } = require('../runJobSearch/runJobSearchActions');
+const { enter_job_title, enter_location,
+    enter_radius, click_search } = require('../runJobSearch/runJobSearchActions');
 
 exports.enter_search = async (req, res, next) => {
     const reqJobTitle = req.body.job_title;
@@ -35,9 +36,10 @@ exports.enter_search = async (req, res, next) => {
     }
 
     try {
-        await enter_job_title(jobTitle)
-        await enter_location(location)
-        await enter_radius(reqRadius)
+        await enter_job_title(jobTitle);
+        await enter_location(location);
+        await enter_radius(reqRadius);
+        await click_search();
         await res.status(200).json({
             success: true,
             search: {

--- a/api/controllers/sessions/runJobSearch/runJobSearchController.js
+++ b/api/controllers/sessions/runJobSearch/runJobSearchController.js
@@ -1,0 +1,5 @@
+
+
+exports.enter_search = async (req, res, next) => {
+    res.status(200).json({ message: 'I hear ya!'})
+}

--- a/api/controllers/sessions/totalJobsLogIn/totalJobsLogInActions.js
+++ b/api/controllers/sessions/totalJobsLogIn/totalJobsLogInActions.js
@@ -2,7 +2,8 @@ const aesjs = require('aes-js');
 const voltPackage = require('../../../volt');
 const volt = voltPackage.open_volt();
 const WebDriver = require('selenium-webdriver');
-const driver = new WebDriver.Builder().forBrowser('chrome').build();
+const localWebDriver = require('../webDriver');
+const driver = localWebDriver.get_driver()
 
 exports.navigate_to_website = async function() {
     const url = 'https://www.totaljobs.com/';

--- a/api/controllers/sessions/totalJobsLogIn/totalJobsLogInController.js
+++ b/api/controllers/sessions/totalJobsLogIn/totalJobsLogInController.js
@@ -1,5 +1,5 @@
-const { navigate_to_website, navigate_to_loginPage, jobSeeker_login } = require('./totalJobsLogInActions');
 const { validate_email } = require('../../../Entities/validationEntity')
+const { navigate_to_website, navigate_to_loginPage, jobSeeker_login } = require('./totalJobsLogInActions');
 
 exports.totalJobs_logIn = async (req, res, next) => {
     const requestEmail = req.body.email;
@@ -43,7 +43,11 @@ exports.totalJobs_logIn = async (req, res, next) => {
                 message: 'Log in unsuccessful, please check email and password'
             })
         } else {
-            await res.status(500).json({ error: err })
+            console.log(err)
+            await res.status(500).json({
+                success: false,
+                message: 'system error'
+            })
         }
     }
 

--- a/api/controllers/sessions/webDriver.js
+++ b/api/controllers/sessions/webDriver.js
@@ -1,0 +1,6 @@
+const WebDriver = require('selenium-webdriver');
+const driver = new WebDriver.Builder().forBrowser('chrome').build();
+
+exports.get_driver = () => {
+    return driver
+}

--- a/api/routes/sessions.js
+++ b/api/routes/sessions.js
@@ -5,12 +5,14 @@ const getAllSessionsController = require('../controllers/sessions/getAllSessions
 const getSessionController = require('../controllers/sessions/getSessionController');
 const postSessionToDBController = require('../controllers/sessions/postSessionToDBController');
 const totalJobsLogInController = require('../controllers/sessions/totalJobsLogIn/totalJobsLogInController');
+const runJobSearchController = require('../controllers/sessions/runJobSearch/runJobSearchController');
 
 router.get('/', checkAuth, getAllSessionsController.get_all_sessions);
 router.post('/', postSessionToDBController.log_session);
 router.get('/:sessionId', checkAuth, getSessionController.get_session);
 
-// session runtime logic
+// SYSTEM RUNTIME LOGIC
 router.post('/totalJobsLogIn', checkAuth, totalJobsLogInController.totalJobs_logIn);
+router.post('/runJobSearch', runJobSearchController.enter_search);
 
 module.exports = router;

--- a/api/routes/sessions.js
+++ b/api/routes/sessions.js
@@ -13,6 +13,6 @@ router.get('/:sessionId', checkAuth, getSessionController.get_session);
 
 // SYSTEM RUNTIME LOGIC
 router.post('/totalJobsLogIn', checkAuth, totalJobsLogInController.totalJobs_logIn);
-router.post('/runJobSearch', runJobSearchController.enter_search);
+router.post('/runJobSearch', checkAuth, runJobSearchController.enter_search);
 
 module.exports = router;


### PR DESCRIPTION
AIM: create a route that enters the job search parameters and lands on results page

- created an instance of the WebDriver to be accessed as needed across the application.
- added the following to documentation: 
    - POST `/api/sessions/totalJobsLogIn` : navigates to totalJobs and logs in
    - POST `/api/sessions/runJobSearch` : enters given search preferences and lands on results page

Created and amended files:
- `api/controllers/sessions/runJobSearch/runJobSearchActions.js` : methods used by runJobSearchController
- `api/controllers/sessions/runJobSearch/runJobSearchController.js` : validates and sanatises request and enters search params
- `api/controllers/sessions/totalJobsLogIn/totalJobsLogInActions.js` : removed instantiating a new driver directly in this single instance of a file...
- `api/controllers/sessions/webDriver.js` : ...and created a stand alone file that creates a single instance of the driver to be passed around as required
- `api/controllers/sessions/totalJobsLogIn/totalJobsLogInController.js` : amended response message when an error is found
- `api/routes/sessions.js` : added new runJobSearch route and made sure authorisation required