### PR TITLE
E4 03 include application limit

### DIFF
--- a/api/controllers/sessions/processSearchResults/processResultsActions/applyToJob.js
+++ b/api/controllers/sessions/processSearchResults/processResultsActions/applyToJob.js
@@ -18,6 +18,7 @@ exports.apply_to_job = async () => {
         return { success: true }
 
     } catch (err) {
+        console.log(err)
         return {
             success: false,
             error: err

--- a/api/controllers/sessions/processSearchResults/processResultsActions/dataBaseRequests/getUserPreferences.js
+++ b/api/controllers/sessions/processSearchResults/processResultsActions/dataBaseRequests/getUserPreferences.js
@@ -51,3 +51,19 @@ exports.get_user_salary = async (id) => {
         }
     }
 }
+
+exports.get_user_session_limit = async (id) => {
+    let userData = await User.findById(id)
+    try {
+        return {
+            success: true,
+            session_limit: userData.preferences.session_limit
+        }
+    } catch (err) {
+        console.log(err)
+        return {
+            success: false,
+            error: err
+        }
+    }
+}

--- a/api/controllers/sessions/processSearchResults/processSearchResultsController.js
+++ b/api/controllers/sessions/processSearchResults/processSearchResultsController.js
@@ -58,6 +58,7 @@ exports.process_results = async (req, res, next) => {
         success: true,
         total_results: totalResults,
         search_params: searchParams.data,
+        processed_results: processed_results,
         session_report: sessionReport.data
     })
 }


### PR DESCRIPTION
added logic to check after assessing each job application, if the current applied count matches or is higher than the user's session limit preference. If the same or higher, exits process and returns session report. 

files changed or added:
- **api/controllers/sessions/processSearchResults/processResults.js** : called 'get_user_session_limit' , and wrote logic to check current applied count against user session limit preference
- **api/controllers/sessions/processSearchResults/processResultsActions/applyToJob.js** : console logging error
- **api/controllers/sessions/processSearchResults/processResultsActions/dataBaseRequests/getUserPreferences.js** : created method to get the user's session limit preference from db
- **api/controllers/sessions/processSearchResults/processSearchResultsController.js** - added processed results to returning successful obj